### PR TITLE
Docker build fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Documentation is available here: http://docs.ohif.org/
 docker-compose up --build
 ```
 
+
 [LesionTracker - http://localhost:3001](http://localhost:3001)
 
 [orthanc for dicom upload - http://localhost:8042](http://localhost:8042)


### PR DESCRIPTION
Hallo @casaper kannst du Issues einschalten für diese Repo? (hier ist eigentlich kein Pull Request)

wenn ich versuche
```
docker-compose up --build
```

kriege ich mehere fehler meldungen

https://github.com/casaper/Viewers/blob/24d8f3855314c565af38fe324297613b60e7899a/lesion_tracker.dockerfile#L34
```
Step 14/26 : RUN meteor build --directory /home/user/app
 ---> Running in d26697363162
This is your first time using Meteor!
Downloading Meteor distribution
Installing a Meteor distribution in your home directory.
tar: .meteor/packages/ecmascript/.0.10.6.ax6hwf.yxlrw++os+web.browser+web.cordova/plugin.compile-ecmascript.os/npm/node_modules/meteor/babel-compiler/node_modules/.bin: Directory renamed before its status could be extracted
tar: .meteor/packages/ddp-server/.2.1.2.148vu96.10goi++os+web.browser+web.cordova/npm/node_modules/.bin: Directory renamed before its status could be extracted
tar: .meteor/packages/ddp-server/.2.1.2.148vu96.10goi++os+web.browser+web.cordova/npm/node_modules: Directory renamed before its status could be extracted
tar: .meteor/packages/ddp-server/.2.1.2.148vu96.10goi++os+web.browser+web.cordova/npm: Directory renamed before its status could be extracted
tar: .meteor/packages/ddp-server/.2.1.2.148vu96.10goi++os+web.browser+web.cordova: Directory renamed before its status could be extracted
tar: .meteor/packages/ddp-server: Directory renamed before its status could be extracted
tar: .meteor/packages/babel-compiler/.7.0.6.l0cij9.maz++os+web.browser+web.cordova/npm/node_modules/regjsparser/node_modules/.bin: Directory renamed before its status could be extracted
tar: .meteor/packages/babel-compiler/.7.0.6.l0cij9.maz++os+web.browser+web.cordova/npm/node_modules/regjsparser/node_modules: Directory renamed before its status could be extracted
tar: .meteor/packages/babel-compiler/.7.0.6.l0cij9.maz++os+web.browser+web.cordova/npm/node_modules/regjsparser: Directory renamed before its status could be extracted
tar: .meteor/packages/babel-compiler/.7.0.6.l0cij9.maz++os+web.browser+web.cordova/npm/node_modules/.bin: Directory renamed before its status could be extracted
tar: .meteor/packages/babel-compiler/.7.0.6.l0cij9.maz++os+web.browser+web.cordova/npm/node_modules: Directory renamed before its status could be extracted
tar: .meteor/packages/babel-compiler/.7.0.6.l0cij9.maz++os+web.browser+web.cordova/npm: Directory renamed before its status could be extracted
tar: .meteor/packages/babel-compiler/.7.0.6.l0cij9.maz++os+web.browser+web.cordova: Directory renamed before its status could be extracted
tar: .meteor/packages/babel-compiler: Directory renamed before its status could be extracted
tar: Exiting with failure status due to previous errors
ERROR: Service 'lesiontracker' failed to build: The command '/bin/sh -c meteor build --directory /home/user/app' returned a non-zero code: 2
```